### PR TITLE
Replace InferAttributes with interfaces

### DIFF
--- a/src/infrastructure/database/sequelize/mappers/checklist-item-mapper.ts
+++ b/src/infrastructure/database/sequelize/mappers/checklist-item-mapper.ts
@@ -1,6 +1,8 @@
-import { InferAttributes } from "sequelize";
 import { ChecklistItem } from "../../../../domain/entities/checklist-item";
-import { ChecklistItemModel } from "../models/checklist-item";
+import {
+  ChecklistItemAttributes,
+  ChecklistItemModel,
+} from "../models/checklist-item";
 
 export class ChecklistItemMapper {
   static toEntity(model: ChecklistItemModel): ChecklistItem {
@@ -22,7 +24,7 @@ export class ChecklistItemMapper {
 
   static toPersistence(
     entity: ChecklistItem
-  ): InferAttributes<ChecklistItemModel> {
+  ): ChecklistItemAttributes {
     return {
       id: entity.id,
       checklistId: entity.checklistId,
@@ -37,7 +39,7 @@ export class ChecklistItemMapper {
 
   static toPersistenceList(
     entities: ChecklistItem[]
-  ): InferAttributes<ChecklistItemModel>[] {
+  ): ChecklistItemAttributes[] {
     return entities.map((e) => this.toPersistence(e));
   }
 }

--- a/src/infrastructure/database/sequelize/mappers/checklist-mapper.ts
+++ b/src/infrastructure/database/sequelize/mappers/checklist-mapper.ts
@@ -1,6 +1,8 @@
-import { InferAttributes } from "sequelize";
 import { Checklist } from "../../../../domain/entities/checklist";
-import { ChecklistModel } from "../models/checklist";
+import {
+  ChecklistAttributes,
+  ChecklistModel,
+} from "../models/checklist";
 import { ChecklistItemMapper } from "./checklist-item-mapper";
 
 export class ChecklistMapper {
@@ -22,7 +24,7 @@ export class ChecklistMapper {
     return models.map((m) => this.toEntity(m));
   }
 
-  static toPersistence(entity: Checklist): InferAttributes<ChecklistModel> {
+  static toPersistence(entity: Checklist): ChecklistAttributes {
     return {
       id: entity.id,
       companyId: entity.companyId,
@@ -35,7 +37,7 @@ export class ChecklistMapper {
 
   static toPersistenceList(
     entities: Checklist[]
-  ): InferAttributes<ChecklistModel>[] {
+  ): ChecklistAttributes[] {
     return entities.map((e) => this.toPersistence(e));
   }
 }

--- a/src/infrastructure/database/sequelize/mappers/feedback-mapper.ts
+++ b/src/infrastructure/database/sequelize/mappers/feedback-mapper.ts
@@ -1,6 +1,5 @@
-import { InferAttributes } from "sequelize";
 import { Feedback } from "../../../../domain/entities/feedback";
-import { FeedbackModel } from "../models/feedback";
+import { FeedbackAttributes, FeedbackModel } from "../models/feedback";
 
 export class FeedbackMapper {
   static toEntity(model: FeedbackModel): Feedback {
@@ -22,7 +21,7 @@ export class FeedbackMapper {
     return models.map((m) => this.toEntity(m));
   }
 
-  static toPersistence(entity: Feedback): InferAttributes<FeedbackModel> {
+  static toPersistence(entity: Feedback): FeedbackAttributes {
     return {
       id: entity.id,
       giverId: entity.giverId,
@@ -40,7 +39,7 @@ export class FeedbackMapper {
 
   static toPersistenceList(
     entities: Feedback[]
-  ): InferAttributes<FeedbackModel>[] {
+  ): FeedbackAttributes[] {
     return entities.map((e) => this.toPersistence(e));
   }
 }

--- a/src/infrastructure/database/sequelize/mappers/invitation-mapper.ts
+++ b/src/infrastructure/database/sequelize/mappers/invitation-mapper.ts
@@ -1,6 +1,5 @@
-import { InferAttributes } from "sequelize";
 import { Invitation } from "../../../../domain/entities/invitation";
-import { InvitationModel } from "../models/invitation";
+import { InvitationAttributes, InvitationModel } from "../models/invitation";
 
 export class InvitationMapper {
   static toEntity(model: InvitationModel): Invitation {
@@ -22,7 +21,7 @@ export class InvitationMapper {
     return models.map((m) => this.toEntity(m));
   }
 
-  static toPersistence(entity: Invitation): InferAttributes<InvitationModel> {
+  static toPersistence(entity: Invitation): InvitationAttributes {
     return {
       id: entity.id,
       companyId: entity.companyId,
@@ -39,7 +38,7 @@ export class InvitationMapper {
 
   static toPersistenceList(
     entities: Invitation[]
-  ): InferAttributes<InvitationModel>[] {
+  ): InvitationAttributes[] {
     return entities.map((e) => this.toPersistence(e));
   }
 }

--- a/src/infrastructure/database/sequelize/mappers/user-mapper.ts
+++ b/src/infrastructure/database/sequelize/mappers/user-mapper.ts
@@ -1,5 +1,4 @@
-import { CreationAttributes, InferAttributes } from "sequelize";
-import { UserModel } from "../models/user";
+import { UserModel, UserAttributes } from "../models/user";
 import { User } from "../../../../domain/entities/user";
 import { FeedbackMapper } from "./feedback-mapper";
 
@@ -25,7 +24,7 @@ export class UserMapper {
     return models.map((m) => this.toEntity(m));
   }
 
-  static toPersistence(entity: User): InferAttributes<UserModel> {
+  static toPersistence(entity: User): UserAttributes {
     return {
       id: entity.id,
       companyId: entity.companyId,
@@ -39,7 +38,7 @@ export class UserMapper {
     };
   }
 
-  static toPersistenceList(entities: User[]): InferAttributes<UserModel>[] {
+  static toPersistenceList(entities: User[]): UserAttributes[] {
     return entities.map((e) => this.toPersistence(e));
   }
 }

--- a/src/infrastructure/database/sequelize/models/checklist-item.ts
+++ b/src/infrastructure/database/sequelize/models/checklist-item.ts
@@ -1,17 +1,26 @@
 import {
   BelongsToGetAssociationMixin,
   DataTypes,
-  InferAttributes,
-  InferCreationAttributes,
   Model,
   Sequelize,
 } from "sequelize";
 import { CompanyModel } from "./company";
 
-export class ChecklistItemModel extends Model<
-  InferAttributes<ChecklistItemModel>,
-  InferCreationAttributes<ChecklistItemModel>
-> {
+export interface ChecklistItemAttributes {
+  id: string;
+  checklistId: string;
+  label: string;
+  description: string | null;
+  weight: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export class ChecklistItemModel
+  extends Model<ChecklistItemAttributes>
+  implements ChecklistItemAttributes
+{
   public id!: string;
   public checklistId!: string;
   public label!: string;

--- a/src/infrastructure/database/sequelize/models/checklist.ts
+++ b/src/infrastructure/database/sequelize/models/checklist.ts
@@ -2,18 +2,25 @@ import {
   BelongsToGetAssociationMixin,
   DataTypes,
   HasManyGetAssociationsMixin,
-  InferAttributes,
-  InferCreationAttributes,
   Model,
   Sequelize,
 } from "sequelize";
 import { CompanyModel } from "./company";
 import { ChecklistItemModel } from "./checklist-item";
 
-export class ChecklistModel extends Model<
-  InferAttributes<ChecklistModel>,
-  InferCreationAttributes<ChecklistModel>
-> {
+export interface ChecklistAttributes {
+  id: string;
+  companyId: string;
+  title: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export class ChecklistModel
+  extends Model<ChecklistAttributes>
+  implements ChecklistAttributes
+{
   public id!: string;
   public companyId!: string;
   public title!: string;

--- a/src/infrastructure/database/sequelize/models/company.ts
+++ b/src/infrastructure/database/sequelize/models/company.ts
@@ -1,8 +1,6 @@
 import {
   DataTypes,
   HasManyGetAssociationsMixin,
-  InferAttributes,
-  InferCreationAttributes,
   Model,
   Optional,
   Sequelize,
@@ -12,10 +10,19 @@ import { RoleEnum } from "../../../../domain/enums/role-enum";
 import { UserModel } from "./user";
 import { InvitationModel } from "./invitation";
 
-export class CompanyModel extends Model<
-  InferAttributes<CompanyModel>,
-  InferCreationAttributes<CompanyModel>
-> {
+export interface CompanyAttributes {
+  id: string;
+  name: string;
+  cpfCnpj: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export class CompanyModel
+  extends Model<CompanyAttributes>
+  implements CompanyAttributes
+{
   public id!: string;
   public name!: string;
   public cpfCnpj!: string;

--- a/src/infrastructure/database/sequelize/models/feedback.ts
+++ b/src/infrastructure/database/sequelize/models/feedback.ts
@@ -1,8 +1,6 @@
 import {
   BelongsToGetAssociationMixin,
   DataTypes,
-  InferAttributes,
-  InferCreationAttributes,
   Model,
   Optional,
   Sequelize,
@@ -11,10 +9,24 @@ import { RoleEnum } from "../../../../domain/enums/role-enum";
 import { CompanyModel } from "./company";
 import { UserModel } from "./user";
 
-export class FeedbackModel extends Model<
-  InferAttributes<FeedbackModel>,
-  InferCreationAttributes<FeedbackModel>
-> {
+export interface FeedbackAttributes {
+  id: string;
+  giverId: string;
+  receiverId: string;
+  checklistId: string;
+  title: string;
+  description: string | null;
+  observation: string | null;
+  score: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export class FeedbackModel
+  extends Model<FeedbackAttributes>
+  implements FeedbackAttributes
+{
   public id!: string;
   public giverId!: string;
   public receiverId!: string;

--- a/src/infrastructure/database/sequelize/models/invitation.ts
+++ b/src/infrastructure/database/sequelize/models/invitation.ts
@@ -1,8 +1,6 @@
 import {
   BelongsToGetAssociationMixin,
   DataTypes,
-  InferAttributes,
-  InferCreationAttributes,
   Model,
   Sequelize,
 } from "sequelize";
@@ -10,10 +8,23 @@ import { Database } from "../sequelize";
 import { RoleEnum } from "../../../../domain/enums/role-enum";
 import { CompanyModel } from "./company";
 
-export class InvitationModel extends Model<
-  InferAttributes<InvitationModel>,
-  InferCreationAttributes<InvitationModel>
-> {
+export interface InvitationAttributes {
+  id: string;
+  companyId: string;
+  name: string;
+  phone: string | null;
+  cpf: string;
+  role: RoleEnum;
+  isAccepted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export class InvitationModel
+  extends Model<InvitationAttributes>
+  implements InvitationAttributes
+{
   public id!: string;
   public companyId!: string;
   public name!: string;

--- a/src/infrastructure/database/sequelize/models/user.ts
+++ b/src/infrastructure/database/sequelize/models/user.ts
@@ -2,8 +2,6 @@ import {
   BelongsToGetAssociationMixin,
   DataTypes,
   HasManyGetAssociationsMixin,
-  InferAttributes,
-  InferCreationAttributes,
   Model,
   Optional,
   Sequelize,
@@ -13,10 +11,22 @@ import { RoleEnum } from "../../../../domain/enums/role-enum";
 import { CompanyModel } from "./company";
 import { FeedbackModel } from "./feedback";
 
-export class UserModel extends Model<
-  InferAttributes<UserModel>,
-  InferCreationAttributes<UserModel>
-> {
+export interface UserAttributes {
+  id: string;
+  companyId: string;
+  name: string;
+  cpf: string;
+  email: string;
+  role: RoleEnum;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export class UserModel
+  extends Model<UserAttributes>
+  implements UserAttributes
+{
   public id!: string;
   public companyId!: string;
   public name!: string;

--- a/src/infrastructure/database/sequelize/repositories/sequelize-checklist-repository.ts
+++ b/src/infrastructure/database/sequelize/repositories/sequelize-checklist-repository.ts
@@ -1,4 +1,3 @@
-import { InferAttributes } from "sequelize";
 import { IChecklistRepository } from "../../../../application/protocols/repositories/checklist-repository";
 import { Checklist } from "../../../../domain/entities/checklist";
 import { ChecklistItemMapper } from "../mappers/checklist-item-mapper";


### PR DESCRIPTION
## Summary
- remove InferAttributes/InferCreationAttributes generics from Sequelize models
- add explicit attribute interfaces for models
- update mappers to use new interfaces
- remove unused InferAttributes import from repository

## Testing
- `npm run build` *(fails: Cannot find module 'bcrypt' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6860a59428ac833382ba337146e80fe1